### PR TITLE
Transaction List with Mutex

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -1,0 +1,22 @@
+name: Automated Actix Tests
+
+on:
+  pull_request:
+    branches: [ master ]
+  workflow_dispatch:
+     branches: [ master ]
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  testing:
+    runs-on: ubuntu-20.04
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Build
+      run: cargo build --verbose
+    - name: Run tests
+      run: cargo test -- --show-output

--- a/README.md
+++ b/README.md
@@ -1,7 +1,11 @@
+[![Automated Actix Tests](https://github.com/bodo-hugo-barwich/actix-blockchain/actions/workflows/testing.yml/badge.svg)](https://github.com/bodo-hugo-barwich/actix-blockchain/actions/workflows/testing.yml)
 
 # NAME
 
-Blockchain Exercise demonstrating the _Proof of Work_ concept
+Blockchain Exercise demonstrating the _Proof of Work_ concept.
+
+This simulates a **Cryptocurrency Node** in simplified version as to limit the scope 
+of the project.
 
 # DESCRIPTION
 
@@ -15,7 +19,7 @@ elegance and speed to a crypto-currency.
 # MOTIVATION
 
 Translating the concepts seen in the blockchain course
-[Blockchain and Smart Contract Introduction](https://www.udemy.com/certificate/UC-75023750-2591-42ce-aeed-c5519c9d7cbd/)
+[Blockchain and Smart Contracts](https://www.udemy.com/certificate/UC-75023750-2591-42ce-aeed-c5519c9d7cbd/)
 in a _Rust_ implementation as a small auto-sufficient Web Application.
 
 # REQUIREMENTS

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -218,6 +218,7 @@ pub async fn main() -> std::io::Result<()> {
                                 .route(web::get().to(dispatch_ping_request)),
                         )
             */
+            // Make the configuration structure also available within the Application
             .app_data(app_config)
             .wrap(Logger::default())
     })

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -27,14 +27,14 @@ use actix_web::middleware::Logger;
 use actix_web::{error, web, App, Error, HttpResponse, HttpServer};
 use futures_util::StreamExt;
 use std::env;
-use std::ops::DerefMut;
 use std::sync::Mutex;
 
 use serde::{Deserialize, Serialize};
 
 use config::AppConfig;
 use miner::{MinerLink, MiningWorker};
-use model::blockchain::{Blockchain, Transaction};
+use model::blockchain::Blockchain;
+use model::transaction::{MutexTransactionList, Transaction};
 
 const MAX_SIZE: usize = 262_144; // max payload size is 256k
 
@@ -63,7 +63,7 @@ pub async fn dispatch_home_page() -> HttpResponse {
 
 /// Handler to add a Transaction to the Blockchain
 pub async fn add_transaction(
-    blockchain_mutex: web::Data<Mutex<Blockchain>>,
+    transaction_mutex: web::Data<MutexTransactionList>,
     mut payload: web::Payload,
 ) -> Result<HttpResponse, Error> {
     // payload is a stream of Bytes objects
@@ -86,28 +86,39 @@ pub async fn add_transaction(
 
             if !request_transaction.is_valid() {
                 eprintln!("POST Transaction: Transaction is invalid");
+
                 return Err(error::ErrorBadRequest("Transaction is invalid"));
             }
 
-            let mut blockchain_guard = blockchain_mutex.lock().unwrap();
-            let blockchain = blockchain_guard.deref_mut();
+            match transaction_mutex.add_transaction(request_transaction) {
+                Ok(_) => {
+                    println!("Transactions: {:?}", transaction_mutex);
 
-            let next_index = blockchain.add_transaction(request_transaction);
+                    //------------------------
+                    // Success Notfication
 
-            println!("Blockchain: {:?}", blockchain);
+                    Ok(HttpResponse::Created().json(ResponseData {
+                        title: String::from("Actix Blockchain API - Success"),
+                        statuscode: 201,
+                        page: String::from("Add Transaction"),
+                        description: format!("Transactions: Transaction is queued for next block"),
+                    }))
+                }
+                Err(e) => {
+                    //------------------------
+                    // Error Notfication
 
-            //------------------------
-            // Success Notfication
-
-            Ok(HttpResponse::Created().json(ResponseData {
-                title: String::from("Actix Blockchain API - Success"),
-                statuscode: 201,
-                page: String::from("Add Transaction"),
-                description: format!(
-                    "Block ({}): Transaction is queued for next block",
-                    next_index
-                ),
-            }))
+                    Ok(HttpResponse::InternalServerError().json(ResponseData {
+                        title: String::from("Actix Blockchain API - Error"),
+                        statuscode: 500,
+                        page: String::from("Add Transaction"),
+                        description: format!(
+                            "Transactions: Transaction could not be added! Message: {:?}",
+                            e
+                        ),
+                    }))
+                }
+            }
         }
         // Payload Parse failed
         Err(e) => {
@@ -166,14 +177,17 @@ pub async fn main() -> std::io::Result<()> {
     );
 
     let blockchain = web::Data::new(Mutex::new(Blockchain::new()));
+    let transactions = web::Data::new(MutexTransactionList::new());
 
-    //Clone the Blockchain for the Mining Worker
+    //Clone the Blockchain and the Transaction Vector for the Mining Worker
     let worker_blockchain = blockchain.clone();
+    let worker_transactions = transactions.clone();
 
     //Create 2 Mining Worker Instances
     let miner = SyncArbiter::start(config.miner_count as usize, move || {
-        // Each Worker needs a copy of the reference to the Blockchain Data
-        MiningWorker::with_data(worker_blockchain.clone())
+        // Each Worker needs a copy of the reference to the Blockchain Data and
+        // the Transaction Vector
+        MiningWorker::with_data(worker_blockchain.clone(), worker_transactions.clone())
     });
     //Create 1 Mining Link Object
     let link = MinerLink::new(miner);
@@ -184,6 +198,7 @@ pub async fn main() -> std::io::Result<()> {
 
         App::new()
             .app_data(blockchain.clone())
+            .app_data(transactions.clone())
             .app_data(link_data)
             .app_data(web::JsonConfig::default().limit(MAX_SIZE)) // <- limit size of the payload (global configuration)
             .service(

--- a/src/model/blockchain.rs
+++ b/src/model/blockchain.rs
@@ -184,13 +184,14 @@ impl Blockchain {
         next_index
     }
 
-    /*    Protocolo de concenso Proof of Work (PoW).
-          Arguments:
-            - previous_proof: Nounce del bloque previo.
-
-          Returns:
-            - new_proof: Devolución del nuevo nounce obtenido con PoW.
-    */
+    /// Proof of Work (PoW) Consensus Protocol.
+    ///
+    /// # Parameters:
+    /// - `transaction_mutex`: List of `Transaction`s to be included in the Block.
+    ///
+    /// # Returns:
+    /// - `new_proof`: The nonce calculated through the PoW.
+    ///
     pub fn proof_of_work(&mut self, transaction_mutex: &web::Data<MutexTransactionList>) -> u64 {
         let last_block = self.get_last_block();
         let last_hash = match last_block {

--- a/src/model/mod.rs
+++ b/src/model/mod.rs
@@ -1,1 +1,14 @@
+/*
+* @author Bodo (Hugo) Barwich
+* @version 2024-12-30
+* @package Blockchain Exercise
+* @subpackage Data Structures
+
+* This Module exports the Rust Structures to store the data of the Blockchain
+*
+*---------------------------------
+* Requirements:
+*/
+
 pub mod blockchain;
+pub mod transaction;

--- a/src/model/transaction.rs
+++ b/src/model/transaction.rs
@@ -1,0 +1,207 @@
+/*
+* @author Bodo (Hugo) Barwich
+* @version 2024-12-30
+* @package Blockchain Exercise
+* @subpackage Transaction Structures
+
+* This Module defines the Rust Structures to store the data of the Blockchain
+*
+*---------------------------------
+* Requirements:
+*/
+
+use serde::{Deserialize, Serialize};
+use std::ops::{Deref, DerefMut};
+use std::sync::Mutex;
+
+//==============================================================================
+// Structure Transaction Declaration
+
+#[derive(Debug, Default, Serialize, Deserialize)]
+pub struct Transaction {
+    pub sender: String,
+    pub receiver: String,
+    pub amount: f64,
+}
+
+//==============================================================================
+// Structure Transaction Declaration
+
+#[derive(Debug)]
+pub struct MutexTransactionList {
+    pub transaction_mutex: Mutex<Vec<Transaction>>,
+}
+
+/// Structure for Email Sending Errors
+#[derive(Debug)]
+pub struct TransactionMutexError {
+    status: String,
+    report: String,
+}
+
+//==============================================================================
+// Structure Transaction Implementation
+
+impl Transaction {
+    /*----------------------------------------------------------------------------
+     * Constructors
+     */
+
+    /// Create a new Transaction.
+    ///
+    /// # Parameters:
+    ///
+    /// - `sender`: Person (Address) which started the transaction
+    /// - `receiver`: Person (Address) which will receive the transaction
+    /// - `amount`: Amount of Cryptocurrency send
+    ///
+    /// # Example:
+    ///
+    /// Create a `Transaction` for the Mining Reward
+    /// ```
+    ///    use model::transaction::Transaction;
+    ///
+    ///    let reward = Transaction::from_data("Blockchain".to_owned(), "Miner".to_owned(), 10f64);
+    /// ```
+    pub fn from_data(sender: String, receiver: String, amount: f64) -> Self {
+        Self {
+            sender: sender,
+            receiver: receiver,
+            amount: amount,
+        }
+    }
+
+    /*----------------------------------------------------------------------------
+     * Consultation Methods
+     */
+
+    /// Check if a Transaction is valid.
+    ///
+    /// The fields `sender` and `receiver` must not be empty and the `amount` field must not be ` 0 `
+    pub fn is_valid(&self) -> bool {
+        !self.sender.is_empty() && !self.receiver.is_empty() && self.amount != 0f64
+    }
+}
+
+//==============================================================================
+// Structure MutexTransactionList Implementation
+
+impl Default for MutexTransactionList {
+    /*----------------------------------------------------------------------------
+     * Default Constructor
+     */
+
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl MutexTransactionList {
+    /*----------------------------------------------------------------------------
+     * Constructors
+     */
+
+    pub fn new() -> Self {
+        Self {
+            transaction_mutex: Mutex::new(Vec::<Transaction>::new()),
+        }
+    }
+
+    pub fn from_vec(transactions: Vec<Transaction>) -> Self {
+        Self {
+            transaction_mutex: Mutex::new(transactions),
+        }
+    }
+
+    /*----------------------------------------------------------------------------
+     * Administration Methods
+     */
+
+    /// Register a Transaction by values.
+    ///
+    /// # Parameters:
+    ///
+    /// - `sender`: Person (Address) which started the transaction
+    /// - `receiver`: Person (Address) which will receive the transaction
+    /// - `amount`: Amount of Cryptocurrency send
+    ///
+    pub fn add_transaction_from_data(
+        &self,
+        sender: &str,
+        receiver: &str,
+        amount: f64,
+    ) -> Result<(), TransactionMutexError> {
+        self.add_transaction(Transaction {
+            sender: sender.to_owned(),
+            receiver: receiver.to_owned(),
+            amount: amount,
+        })
+    }
+
+    /// Register a Transaction by structure.
+    ///
+    /// # Parameters:
+    ///
+    /// - `transaction`: `Transaction` to be added. It will be published as soon as
+    /// a new block is mined.
+    ///
+    pub fn add_transaction(&self, transaction: Transaction) -> Result<(), TransactionMutexError> {
+        match self.transaction_mutex.lock() {
+            Ok(mut guard) => {
+                let transactions = guard.deref_mut();
+
+                transactions.push(transaction);
+
+                Ok(())
+            }
+            Err(e) => Err(TransactionMutexError {
+                status: "failed".to_owned(),
+                report: format!("Transaction List: Mutex Lock failed! Message: {:?}", e),
+            }),
+        }
+    }
+
+    /*----------------------------------------------------------------------------
+     * Consultation Methods
+     */
+
+    pub fn into_vec(&self) -> Vec<Transaction> {
+        match self.transaction_mutex.lock() {
+            Ok(mut guard) => {
+                let transactions = guard.deref_mut();
+                let mut export = Vec::<Transaction>::with_capacity(transactions.len());
+
+                transactions.drain(..).for_each(|t| export.push(t));
+
+                export
+            }
+            Err(mut e) => {
+                eprintln!("Transaction List: Mutex Lock failed! Message: {:?}", e);
+
+                let transactions = e.get_mut();
+                let mut export = Vec::<Transaction>::with_capacity(transactions.len());
+
+                transactions.drain(..).for_each(|t| export.push(t));
+
+                export
+            }
+        }
+    }
+
+    pub fn get_count(&self) -> usize {
+        match self.transaction_mutex.lock() {
+            Ok(guard) => {
+                let transactions = guard.deref();
+
+                transactions.len()
+            }
+            Err(e) => {
+                eprintln!("Transaction List: Mutex Lock failed! Message: {:?}", e);
+
+                let transactions = e.get_ref();
+
+                transactions.len()
+            }
+        }
+    }
+}

--- a/src/model/transaction.rs
+++ b/src/model/transaction.rs
@@ -33,7 +33,7 @@ pub struct MutexTransactionList {
 }
 
 /// Structure for Email Sending Errors
-#[derive(Debug)]
+#[derive(Debug, PartialEq)]
 pub struct TransactionMutexError {
     status: String,
     report: String,
@@ -59,7 +59,7 @@ impl Transaction {
     ///
     /// Create a `Transaction` for the Mining Reward
     /// ```
-    ///    use model::transaction::Transaction;
+    ///    use blockchain_api::model::transaction::Transaction;
     ///
     ///    let reward = Transaction::from_data("Blockchain".to_owned(), "Miner".to_owned(), 10f64);
     /// ```
@@ -204,4 +204,122 @@ impl MutexTransactionList {
             }
         }
     }
+}
+
+//==============================================================================
+// Unit Tests
+
+/*
+Recreating the Test Data:
+
+    $ curl -v http://localhost:3100/add_transaction -d '{"sender":"sender1","receiver":"receiver1","amount":5.67}' | jq '.'
+
+*/
+
+#[test]
+fn transaction_list_from_vec() {
+    //-------------------------------------
+    // Create a `MutexTransactionList` from a Vector
+
+    let mut transactions = Vec::<Transaction>::with_capacity(3);
+
+    transactions.push(Transaction {
+        sender: "sender1".to_owned(),
+        receiver: "receiver1".to_owned(),
+        amount: 5.67f64,
+    });
+    transactions.push(Transaction {
+        sender: "sender2".to_owned(),
+        receiver: "receiver2".to_owned(),
+        amount: 7.89107f64,
+    });
+    transactions.push(Transaction {
+        sender: "sender3".to_owned(),
+        receiver: "receiver3".to_owned(),
+        amount: 9.101113f64,
+    });
+
+    let transaction_count = transactions.len();
+
+    assert_eq!(transaction_count, 3);
+
+    let transaction_mutex = MutexTransactionList::from_vec(transactions);
+
+    let transaction_count = transaction_mutex.get_count();
+
+    assert_eq!(transaction_count, 3);
+}
+
+#[test]
+fn add_transaction_from_data() {
+    //-------------------------------------
+    // Create a `Transaction` from a data set
+    // Transaction List does not need to be `mut` because it is a `Mutex`
+
+    let transaction_mutex = MutexTransactionList::new();
+
+    let transaction_count = transaction_mutex.get_count();
+
+    assert_eq!(transaction_count, 0);
+
+    let result = transaction_mutex.add_transaction_from_data("sender1", "receiver1", 5.67);
+
+    assert_eq!(result.err(), None);
+
+    let result = transaction_mutex.add_transaction_from_data("sender2", "receiver2", 7.89107);
+
+    assert_eq!(result.err(), None);
+
+    let result = transaction_mutex.add_transaction_from_data("sender3", "receiver3", 9.101113);
+
+    assert_eq!(result.err(), None);
+
+    let transaction_count = transaction_mutex.get_count();
+
+    assert_eq!(transaction_count, 3);
+
+    let transactions = transaction_mutex.into_vec();
+
+    assert_eq!(transactions.len(), 3);
+
+    let transaction_count = transaction_mutex.get_count();
+
+    assert_eq!(transaction_count, 0);
+}
+
+#[test]
+fn add_transaction_as_structure() {
+    //-------------------------------------
+    // Create a Transaction from a pre-built structure
+    // Transaction List does not need to be `mut` because it is a `Mutex`
+
+    let transaction_mutex = MutexTransactionList::new();
+
+    let result = transaction_mutex.add_transaction(Transaction {
+        sender: "sender1".to_owned(),
+        receiver: "receiver1".to_owned(),
+        amount: 5.67f64,
+    });
+
+    assert_eq!(result.err(), None);
+
+    let result = transaction_mutex.add_transaction(Transaction {
+        sender: "sender2".to_owned(),
+        receiver: "receiver2".to_owned(),
+        amount: 7.89107f64,
+    });
+
+    assert_eq!(result.err(), None);
+
+    let result = transaction_mutex.add_transaction(Transaction {
+        sender: "sender3".to_owned(),
+        receiver: "receiver3".to_owned(),
+        amount: 9.101113f64,
+    });
+
+    assert_eq!(result.err(), None);
+
+    let transaction_count = transaction_mutex.get_count();
+
+    assert_eq!(transaction_count, 3);
 }

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -1,0 +1,111 @@
+#[cfg(test)]
+mod tests {
+    use actix::sync::SyncArbiter;
+    use actix_web::{http::header::ContentType, test, web, App};
+
+    use std::sync::Mutex;
+
+    use blockchain_api::miner::{MinerLink, MiningResponse, MiningWorker};
+    use blockchain_api::model::blockchain::Blockchain;
+    use blockchain_api::model::transaction::{MutexTransactionList, Transaction};
+    use blockchain_api::{
+        add_transaction, dispatch_home_page, dispatch_mining_request, ResponseData,
+    };
+
+    #[actix_rt::test]
+    async fn test_home() {
+        let mut app =
+            test::init_service(App::new().route("/", web::get().to(dispatch_home_page))).await;
+        let req = test::TestRequest::with_header("content-type", ContentType::json()).to_request();
+
+        let resp = test::call_service(&mut app, req).await;
+
+        println!("home hdrs: '{:?}'", resp);
+
+        assert!(resp.status().is_success());
+
+        let response: ResponseData = test::read_body_json(resp).await;
+
+        println!("send bdy: '{:?}'", response);
+
+        assert_eq!(response.page.as_str(), "Home");
+        assert_eq!(response.statuscode, 200);
+    }
+
+    #[actix_rt::test]
+    async fn test_add_transaction() {
+        let transactions = web::Data::new(MutexTransactionList::new());
+
+        let mut app = test::init_service(
+            App::new()
+                .app_data(transactions.clone())
+                .route("/add_transaction", web::post().to(add_transaction)),
+        )
+        .await;
+
+        let transaction = Transaction {
+            sender: String::from("sender1"),
+            receiver: String::from("receiver1"),
+            amount: 11.1317f64,
+        };
+
+        let req = test::TestRequest::post()
+            .uri("/add_transaction")
+            .set_json(&transaction)
+            .to_request();
+
+        let resp = test::call_service(&mut app, req).await;
+
+        println!("add tx hdrs: '{:?}'", resp);
+
+        assert!(resp.status().is_success());
+
+        let response: ResponseData = test::read_body_json(resp).await;
+
+        println!("send bdy: '{:?}'", response);
+
+        assert_eq!(response.page.as_str(), "Add Transaction");
+        assert_eq!(response.statuscode, 201);
+    }
+
+    #[actix_rt::test]
+    async fn test_mining() {
+        let blockchain = web::Data::new(Mutex::new(Blockchain::new()));
+        let transactions = web::Data::new(MutexTransactionList::new());
+
+        //Clone the Blockchain and the Transaction Vector for the Mining Worker
+        let worker_blockchain = blockchain.clone();
+        let worker_transactions = transactions.clone();
+
+        //Create 1 Mining Worker Instances
+        let miner = SyncArbiter::start(1, move || {
+            // Each Worker needs a copy of the reference to the Blockchain Data and
+            // the Transaction Vector
+            MiningWorker::with_data(worker_blockchain.clone(), worker_transactions.clone())
+        });
+        //Create 1 Mining Link Object
+        let link = MinerLink::new(miner);
+
+        let mut app = test::init_service(
+            App::new()
+                .app_data(blockchain.clone())
+                .app_data(transactions.clone())
+                .app_data(web::Data::new(link.clone()))
+                .route("/mine_block", web::get().to(dispatch_mining_request)),
+        )
+        .await;
+
+        let req = test::TestRequest::get().uri("/mine_block").to_request();
+        let resp = test::call_service(&mut app, req).await;
+
+        println!("mining hdrs: '{:?}'", resp);
+
+        assert!(resp.status().is_success());
+
+        let response: MiningResponse = test::read_body_json(resp).await;
+
+        println!("send bdy: '{:?}'", response);
+
+        assert_eq!(response.status.as_str(), "success");
+    }
+}


### PR DESCRIPTION
This separates the `Transaction` list into its own structure and protects them with a separate `Mutex`. 

This enables the **Transactions** not to be locked the whole time during the **Mining Process**.

Incoming Transactions are only updated once every second when also the block timestamp is updated.\
This is also a measure not to lock the transactions continuously during the Mining Process  due to the high frequency iteration rate.

The **Transaction List** several methods to access the transactions or to query its status encapsulating the **Mutex Locking** logic.

closes #1 